### PR TITLE
Do some neat logging tricks

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,40 @@ const net = require('net');
 const node_static = require('node-static');
 const querystring = require('querystring');
 const sockjs = require('sockjs');
+const winston = require('winston');
+const winstonConf = require('winston-config');
+const yargs = require('yargs');
+
+var argv = yargs
+    .usage('Usage: $0 <command> [options]')
+    .alias('l', 'log-config')
+    .nargs('1', 1)
+    .describe('l', 'Load winston config logging from file')
+    .help('h')
+    .alias('h', 'help')
+    .argv;
+
+if (argv.l) {
+    var logger = winstonConf.fromFileSync(argv.l);
+
+    var appLogger = logger.loggers.get('application');
+    var telnetLogger = logger.loggers.get('telnet');
+} else {
+    var logger = new winston.Logger({
+        transports: [
+            new winston.transports.Console({
+                level: 'debug',
+                handleExceptions: true,
+                json: false,
+                colorize: true
+            })
+        ],
+        exitOnError: true
+    });
+
+    var appLogger = logger;
+    var telnetLogger = logger;
+}
 
 var matcher = new CIDRMatcher([ '10.0.0.0/8', '172.16.30.0/24' ]);
 
@@ -19,22 +53,23 @@ sockjs_server.on('connection', function(conn) {
     loc = conn.url.indexOf("?");
 
     if (loc < 0) {
-        console.log("no query string found");
+        appLogger.info("no query string found");
         conn.close()
         return;
     }
 
-    qs = querystring.parse(conn.url.substring(loc + 1));
-    host = qs["host"];
+    qs = conn.url.substring(loc + 1)
+    params = querystring.parse(qs);
+    host = params["host"];
 
     if (!host) {
-        console.log('host not specified in query string');
+        appLogger.info('host not specified in query string: ' + qs);
         conn.close()
         return;
     }
 
     if (!matcher.contains(host)) {
-        console.log("Attempt to proxy to an unauthorized IP: " + host);
+        appLogger.warning("Attempt to proxy to an unauthorized IP: " + host);
         conn.close();
         return;
     }
@@ -43,7 +78,7 @@ sockjs_server.on('connection', function(conn) {
         // this callback gets triggered when a successful connection is established
 
         client.on('close', function(had_error) {
-            console.log("telnet connection closed");
+            telnetLogger.debug("telnet connection closed");
             conn.close();
         });
 
@@ -62,16 +97,16 @@ sockjs_server.on('connection', function(conn) {
     client.on('error', function(err) {
         // this handler is outside the connect callback to handle errors before
         // connect occurs
-        console.log("error: " + err.message);
+        telnetLogger.warning("Error: " + err.message);
         conn.write('error: ' +  err.message);
         conn.end()
     });
 
-    console.log("setup complete to IP: " + host);
+    appLogger.debug("setup complete to IP: " + host);
 
     conn.on('data', function(message) {
         // we shouldn't receive any information from the websocket.
-        console.log("data received on websocket: " + message);
+        telnetLogger.warning("data received on websocket: " + message);
     });
 
     conn.on('close', function() {
@@ -93,5 +128,5 @@ server.addListener('upgrade', function(req,res) {
 
 sockjs_server.installHandlers(server, { prefix: '/sock' });
 
-console.log('listening on ' + node_host + ':' + node_port);
+appLogger.info('listening on ' + node_host + ':' + node_port);
 server.listen(node_port, node_host);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "cidr-matcher": "^1.0.5",
     "node-static": "^0.7.9",
-    "sockjs": "^0.3.18"
+    "sockjs": "^0.3.18",
+    "winston": "^2.3.1",
+    "winston-config": "^0.5.1",
+    "yargs": "^7.1.0"
   }
 }


### PR DESCRIPTION
After a whole bunch of work trying to figure out how to capture stderr
logs from journald to get them onto disk I realize that nodejs is
basically an application like any other and it can just log to disk.
There is even a library that lets you do something python logging like
and configure it by file.

This will make logging to a directory much easier.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>