### PR TITLE
Clarify license and package.json issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+
+Apache Software License 2.0
+
+Copyright (c) 2016, Jamie Lennox
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/package.json
+++ b/package.json
@@ -9,5 +9,10 @@
     "winston": "^2.3.1",
     "winston-config": "^0.5.1",
     "yargs": "^7.1.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/BonnyCI/logging-proxy.git"
   }
 }


### PR DESCRIPTION
NPM complains because there's no license or repository defined.
Particularly the license is something we should clarify.

Declaring it Apache-2.0 as everything else is.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>