### PR TITLE
Set user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY package.json /usr/src/app/
 RUN npm install && npm cache clean
 COPY . /usr/src/app
 
+USER node
 EXPOSE 3000
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
The nodejs base docker image creates a node user but then doesn't
actually do anything with it. There's no reason our node script needs to
run as root so lock it down to that user.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>