### PR TITLE
Remove grunt-contrib-jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "grunt": "^1.0.1",
-    "grunt-contrib-jshint": "^1.1.0",
     "grunt-eslint": "^19.0.0",
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.2.0",


### PR DESCRIPTION
This should have been part of the last patch that removed all the JSHint
stuff.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>