### PR TITLE
Use strict equality even on null

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,3 +6,6 @@ env:
 plugins:
   - standard
   - promise
+rules:
+  eqeqeq: 2
+  no-eq-null: 2

--- a/sock/index.js
+++ b/sock/index.js
@@ -74,7 +74,7 @@ function createClient (conn) {
 function onConnection (conn) {
   var params = getParams(conn.url)
 
-  if (params == null) {
+  if (params === null) {
     conn.end()
     return
   }


### PR DESCRIPTION
Use eslint to enforce the === even on null. The JS equality thing still
confuses me so lets just never use it.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>